### PR TITLE
Add `pass_filenames: false` to pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,3 +6,4 @@
   minimum_pre_commit_version: 3.0.0
   types: [text]
   files: \.(ftl)$
+  pass_filenames: false


### PR DESCRIPTION
I was getting duplicate error output with the current hook. I conceptually had things wrong about how this worked. The pre-commit hook expects individual files to be passed to it so that if you change a file and commit it to the repo, it passes the changed file(s) for checking (if they match the pattern defined in the `types` and `files`. However, this linter expects a directory path that it scans all files within. The `pass_filenames: false` allows it to work more in the style of this linter by just executing whenever a commit happens. The reason I saw the duplicate error messages was because it was scanning the paths provided via the args for each file passed to it, so it was executing multiple times. This fixes that.

Apologies for missing this the first time around.