### PR TITLE
Use relative path from `os.curdir` in error messages

### DIFF
--- a/src/fluent_linter/linter.py
+++ b/src/fluent_linter/linter.py
@@ -534,7 +534,7 @@ class Linter(visitor.Visitor):
     def add_error(self, node, message_id, rule, msg):
         (col, line) = self.span_to_line_and_col(node.span)
 
-        file_path = os.path.relpath(self.path, self.root_folder)
+        file_path = os.path.relpath(self.path)
         message_id = message_id if message_id is not None else "-"
         error_msg = f"""
             File path: {file_path}


### PR DESCRIPTION
If passing multiple folders to the linter, the error outputs only the part of the path within that folder, making it hard to find which files contain the error.

Using `relpath` without the `root_folder` defaults to `os.curdir` which then includes the full relative path like was passed in via the args.

In our case in bedrock, we call `moz-fluent-lint --config path/to/config.yaml l10n/en/ l10n/en-US/ l10n-pocket/en/`

The error output:

Before:
```
    File path: footer.ftl
    Message ID: pocket_footer-get-the-app
    Position: line 23 column 1
    Error (ID01): Identifiers may only contain lowercase characters and -
```

After:
```
    File path: l10n-pocket/en/footer.ftl
    Message ID: pocket_footer-get-the-app
    Position: line 23 column 1
    Error (ID01): Identifiers may only contain lowercase characters and -
```